### PR TITLE
OIPA-2093

### DIFF
--- a/OIPA/api/renderers.py
+++ b/OIPA/api/renderers.py
@@ -878,7 +878,7 @@ class IATIXMLRenderer(BaseRenderer):
         elif view_class_name in ['ActivityList', 'OrganisationList']:
             if 'results' in data:
                 data = data['results']
-                if data[0]["sectors"]:
+                if data and data[0].get("sectors"):
                     ElementReference.activity_sector = True
             self.xml = E(self.root_tag_name)
             self.xml.set('version', self.version)


### PR DESCRIPTION
fix: organisation/total-expenditure/expense-line/value not parsed for version 202 issue
https://app.zenhub.com/workspaces/iaticloud-5b8e865bb2cc7b6c78ece322/issues/zimmerman-zimmerman/iati.cloud/2093