### PR TITLE
Oipa-2225

### DIFF
--- a/OIPA/api/iati/references.py
+++ b/OIPA/api/iati/references.py
@@ -3,7 +3,7 @@ This module reletated to IATI Standard version 2.03
 http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/
 """
 from lxml import etree
-from celery.contrib import rdb
+
 from api.iati.attributes import DataAttribute
 from api.iati.elements import (
     AttributeRecord, ElementBase, ElementRecord, ElementReference,

--- a/OIPA/api/iati/references.py
+++ b/OIPA/api/iati/references.py
@@ -3,7 +3,7 @@ This module reletated to IATI Standard version 2.03
 http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/
 """
 from lxml import etree
-
+from celery.contrib import rdb
 from api.iati.attributes import DataAttribute
 from api.iati.elements import (
     AttributeRecord, ElementBase, ElementRecord, ElementReference,
@@ -1089,12 +1089,11 @@ class SectorReference(ElementWithNarrativeReference):
             self.percentage.get('key')
         )
         if percentage_value:
-            if percentage_value == 100.00:
-                # we don't want decimals in 100.
-                percentage_value_in_str = (str(percentage_value))[:-3]
-            else:
-                percentage_value_in_str = str(percentage_value)
-
+            # Percentage value type is {Decimal}, then convert it to string
+            percentage_value_in_str = str(percentage_value)
+            # We don't want to display the .00 used for our calculations
+            if percentage_value_in_str[-3:] == '.00':
+                percentage_value_in_str = percentage_value_in_str[:-3]
             sector_element.set(
                 self.percentage.get('attr'),
                 percentage_value_in_str
@@ -1440,10 +1439,14 @@ class RecipientCountryReference(ElementWithNarrativeReference):
         # @percentage
         percentage_value = self.data.get(self.percentage.get('key'))
         if percentage_value is not None:
+            # Percentage value type is {Decimal}, then convert it to string
+            percentage_value_in_str = str(percentage_value)
+            # We don't want to display the .00 used for our calculations
+            if percentage_value_in_str[-3:] == '.00':
+                percentage_value_in_str = percentage_value_in_str[:-3]
             recipient_country_element.set(
                 self.percentage.get('attr'),
-                # Percentage value type is {Decimal}, then convert it to string
-                str(percentage_value)
+                percentage_value_in_str
             )
         self.create_narrative(recipient_country_element)
 
@@ -1501,10 +1504,14 @@ class RecipientRegionReference(ElementWithNarrativeReference):
         # @percentage
         percentage_value = self.data.get(self.percentage.get('key'))
         if percentage_value:
+            # Percentage value type is {Decimal}, then convert it to string
+            percentage_value_in_str = str(percentage_value)
+            # We don't want to display the .00 used for our calculations
+            if percentage_value_in_str[-3:] == '.00':
+                percentage_value_in_str = percentage_value_in_str[:-3]
             recipient_region_element.set(
                 self.percentage.get('attr'),
-                # Percentage value type is {Decimal}, then convert it to string
-                str(percentage_value)
+                percentage_value_in_str
             )
 
         # @vocabulary


### PR DESCRIPTION
We needed to keep the decimal point in the database in order to make calculations
but we had to change it in the output so we could compare the original-XML with the output-XML (ie suppress the zeros after the decimal point and the decimal point)

Issue that might be raise by this change :  if the original iati document has a percentage with a decimal point followed by 00 the decimal point and 00 will not appear
There is very little chance that this will happen as percentage are rarely using a decimal point

note : the issue did not arise when sector.percentage was ‘100', it had been fixed for this number only  (api/iati/references l1084)

Issue fixed on the following fields for the XML output :
-recipient_country.percentage
-recipient_region.percentage
-sector.percentage

for each of those we check if the value finish by ".00" and we suppress the end if it is the case